### PR TITLE
feat!: migrate to null-safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages
 pubspec.lock
 *delme*
 .packages
+.dart_tool

--- a/lib/src/yaml_writer.dart
+++ b/lib/src/yaml_writer.dart
@@ -3,8 +3,6 @@
 
 library yaml.writer;
 
-import 'package:quiver_iterables/iterables.dart';
-
 /// Serializes [node] into a String and returns it.
 String toYamlString(node) {
   var sb = new StringBuffer();
@@ -65,8 +63,11 @@ Iterable<String> _sortKeys(Map m) {
     }
   });
 
-  return concat([simple..sort(), maps..sort(), other..sort()])
-      as Iterable<String>;
+  return [
+    ...simple..sort(),
+    ...maps..sort(),
+    ...other..sort(),
+  ];
 }
 
 void _listToYamlString(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ description: "A library for writing yaml files"
 homepage: "https://github.com/Andersmholmgren/yamlicious"
 name: "yamlicious"
 version: "0.0.5"
-dependencies: 
-  quiver_iterables: "^1.0.0"
-dev_dependencies: 
-  test: "^0.12.7"
-  yaml: "^2.1.8"
-environment: 
-  sdk: ">=1.8.0 <2.0.0"
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dev_dependencies:
+  test: ^1.17.5
+  yaml: ^3.1.0


### PR DESCRIPTION
This migrates yamlicious

The dependency on quiver_iterables was removed because it is not compatible with Dart 2